### PR TITLE
Allow bold and italic within list items.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,6 +164,8 @@ class List {
       style: {},
       items: {
         br: true,
+        b: true,
+        i: true
       }
     };
   }


### PR DESCRIPTION
The editor allows you to create bold and italic items within lists, this small change will actually save that data. Current behaviour is to ignore bold and italic spans.