### PR TITLE
Add Documentation for I18n Support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,18 @@ Object `Item`:
     }
 },
 ```
+## I18n support
+
+This tool supports the [i18n api](https://editorjs.io/i18n-api).
+To localize UI labels, put this object to your i18n dictionary under the `tools` section:
+
+```json
+"tools": {
+  "list": {
+    "Ordered": "ממוספר",
+    "Unordered": "לא ממוספר"
+  }
+}
+```
+
+See more instructions about Editor.js internationalization here: [https://editorjs.io/internationalization](https://editorjs.io/internationalization)


### PR DESCRIPTION
### Summary 

This PR updates the README to include information about the support for the I18n API within the Nested List Tool for Editor.js. It provides a detailed example on how to localize UI labels using the i18n dictionary under the `tools` section. A reference to more in-depth instructions on Editor.js internationalization is also included.

### Key Additions

- Explanation on how the tool supports the i18n API
- Code snippet demonstrating how to use the i18n dictionary for UI label localization
- Link to further documentation on Editor.js internationalization

These additions will help users who are new to the tool understand its i18n capabilities and how to use them effectively.

### Related Issues 

- [Documentation Lacks Information on Localizing "Unordered" and "Ordered" #54](https://github.com/editor-js/nested-list/issues/54)

### Type of change

Documentation Update

### Checklist

- [x] I have updated the documentation accordingly
- [x] I have linked the related issue
- [x] This PR is ready for review

### How was this tested?

Visual review of the updated README content was performed to confirm correct markdown syntax and accurate content description.
