### PR TITLE
permit to use linebreak

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/list",
-  "version": "2.0.2",
+  "version": "2.0.7",
   "keywords": [
     "codex editor",
     "list",

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -167,7 +167,9 @@ export default class ListTabulator<Renderer extends ListRenderer> {
         (event) => {
           switch (event.key) {
             case 'Enter':
-              this.enterPressed(event);
+              if (!event.shiftKey) {
+                this.enterPressed(event);
+              }
               break;
             case 'Backspace':
               this.backspace(event);


### PR DESCRIPTION
> This check will allow users to use line breaks within list elements

Same than https://github.com/editor-js/list/pull/36 on updated codebase

it resolves https://github.com/editor-js/list/issues/67