### PR TITLE
Support for optional counter types for ordered list

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ var editor = EditorJS({
 |--------------|----------|----------------------------------------------------------------|
 | defaultStyle | `string` | default list style: `ordered`, `unordered` or `checklist`, default is `unordered` |
 | maxLevel     | `number` | maximum level of the list nesting, could be set to `1` to disable nesting, unlimited by default |
+| counterTypes | `string[]` | specifies which counter types should be shown in the ordered list style, could be set to `['numeric','upper-roman']`, default is `undefined` which shows all counter types |
 
 ## Output data
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/list",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": [
     "codex editor",
     "list",

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,11 @@ export default class EditorjsList {
   private defaultListStyle?: ListConfig['defaultStyle'];
 
   /**
+   * Default Counter type of the ordered list
+   */
+  private defaultCounterTypes: OlCounterType[];
+
+  /**
    * Tool's data
    */
   private data: ListData;
@@ -209,6 +214,11 @@ export default class EditorjsList {
      * Set the default list style from the config or presetted 'unordered'.
      */
     this.defaultListStyle = this.config?.defaultStyle || 'unordered';
+
+    /**
+     * Set the default counter types for the ordered list
+     */
+    this.defaultCounterTypes = this.config?.counterTypes || ['numeric', 'upper-roman', 'lower-roman', 'upper-alpha', 'lower-alpha'];
 
     const initialData = {
       style: this.defaultListStyle,
@@ -342,9 +352,15 @@ export default class EditorjsList {
        * For each counter type in OlCounterType create toolbox item
        */
       OlCounterTypesMap.forEach((_, counterType: string) => {
+        const counterTypeValue = OlCounterTypesMap.get(counterType)! as OlCounterType;
+
+        if (!this.defaultCounterTypes.includes(counterTypeValue)) {
+          return;
+        }
+
         orderedListCountersTunes.children.items!.push({
-          title: this.api.i18n.t(counterType),
-          icon: OlCounterIconsMap.get(OlCounterTypesMap.get(counterType)!),
+          title: this.api.i18n.t(counterTypeValue),
+          icon: OlCounterIconsMap.get(counterTypeValue),
           isActive: (this.data.meta as OrderedListItemMeta).counterType === OlCounterTypesMap.get(counterType),
           closeOnActivate: true,
           onActivate: () => {
@@ -415,39 +431,39 @@ export default class EditorjsList {
     switch (this.listStyle) {
       case 'ordered':
         this.list = new ListTabulator<OrderedListRenderer>({
-          data: this.data,
-          readOnly: this.readOnly,
-          api: this.api,
-          config: this.config,
-          block: this.block,
-        },
-        new OrderedListRenderer(this.readOnly, this.config)
+            data: this.data,
+            readOnly: this.readOnly,
+            api: this.api,
+            config: this.config,
+            block: this.block,
+          },
+          new OrderedListRenderer(this.readOnly, this.config)
         );
 
         break;
 
       case 'unordered':
         this.list = new ListTabulator<UnorderedListRenderer>({
-          data: this.data,
-          readOnly: this.readOnly,
-          api: this.api,
-          config: this.config,
-          block: this.block,
-        },
-        new UnorderedListRenderer(this.readOnly, this.config)
+            data: this.data,
+            readOnly: this.readOnly,
+            api: this.api,
+            config: this.config,
+            block: this.block,
+          },
+          new UnorderedListRenderer(this.readOnly, this.config)
         );
 
         break;
 
       case 'checklist':
         this.list = new ListTabulator<CheckListRenderer>({
-          data: this.data,
-          readOnly: this.readOnly,
-          api: this.api,
-          config: this.config,
-          block: this.block,
-        },
-        new CheckListRenderer(this.readOnly, this.config)
+            data: this.data,
+            readOnly: this.readOnly,
+            api: this.api,
+            config: this.config,
+            block: this.block,
+          },
+          new CheckListRenderer(this.readOnly, this.config)
         );
 
         break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,7 +359,7 @@ export default class EditorjsList {
         }
 
         orderedListCountersTunes.children.items!.push({
-          title: this.api.i18n.t(counterTypeValue),
+          title: this.api.i18n.t(counterType),
           icon: OlCounterIconsMap.get(counterTypeValue),
           isActive: (this.data.meta as OrderedListItemMeta).counterType === OlCounterTypesMap.get(counterType),
           closeOnActivate: true,

--- a/src/types/ListParams.ts
+++ b/src/types/ListParams.ts
@@ -1,4 +1,5 @@
 import type { ItemMeta } from './ItemMeta';
+import type { OlCounterType } from './OlCounterType';
 
 /**
  * list style to make list as ordered or unordered
@@ -87,4 +88,10 @@ export interface ListConfig {
    * If nesting is not needed, it could be set to 1
    */
   maxLevel?: number;
+  /**
+   * Specifies which counter types should be shown in the ordered list style selector.
+   * @example ['numeric', 'upper-roman'] // Shows selector with these two options
+   * @default undefined // All counter types are available when not specified
+   */
+  counterTypes?: OlCounterType[];
 }


### PR DESCRIPTION
The current version has a fixed list of counter types, which are the default options for ordered list.

So this PR allows an optional way to specify a list on what counter types should be visible.

Example
```
 tools: {
        List: {
          class: List,
          config: {
             counterTypes: ['numeric', 'upper-roman']
          }
        },
      },
```

![image](https://github.com/user-attachments/assets/fc3d1f1d-f14a-48d0-aa3f-f0cfdd994405)

Closes #128 
