### PR TITLE
Imp(docs): update docs with localisation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,35 @@ Object `ItemMeta` for Ordered list
 
 Object `ItemMeta` for Unordered list would be empty.
 
+## Localisation
+If you want to use your language for toolbox items, you can pass i18n dictionary to the editorjs instance below the tools `block`:
+```javascript
+i18n: { 
+  messages: {
+    "toolNames": {
+      "Ordered List": "Nummerierte Liste",
+      "Unordered List": "Unnummeriert Liste",
+      "Checklist": "Checkliste",
+    },
+    "tools": {
+      "List": {
+        'Unordered': 'Unnummeriert',
+        'Ordered': 'Nummerierte',
+        'Checklist': 'Checkliste',
+      }
+    },
+  },
+},
+```
+
+### Other supported keys for `tools.List`
+- `Start with`
+- `Counter type`
+- `Numeric`
+- `Lower Roman`
+- `Upper Roman`
+- `Lower Alpha`
+- `Upper Alpha`
 
 ## Example of the content for `Unordered List`
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/list",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "keywords": [
     "codex editor",
     "list",

--- a/playground/index.html
+++ b/playground/index.html
@@ -104,6 +104,25 @@
           }
         },
       },
+      /**
+       * Example of the lacalisation dictionary
+       */
+      i18n: { 
+        messages: {
+          "toolNames": {
+            "Ordered List": "Nummerierte Liste",
+            "Unordered List": "Unnummeriert Liste",
+            "Checklist": "Checkliste",
+          },
+          "tools": {
+            "List": {
+              'Unordered': 'Unnummeriert',
+              'Ordered': 'Nummerierte',
+              'Checklist': 'Checkliste',
+            }
+          },
+        },
+      },
 
       /**
        * This Tool will be used as default


### PR DESCRIPTION
Added example of i18n usage in `readme` and `example/index.html`
<img width="961" alt="image" src="https://github.com/user-attachments/assets/647448ac-2b17-4079-a37b-9f3be031753b" />

resolves #54 