### PR TITLE
Issues/#135

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -399,7 +399,16 @@ export default class EditorjsList {
         this.listStyle = 'unordered';
     }
 
-    this.list!.onPaste(event);
+    // update the data first with the formatted list data from the paste handler
+    this.data = this.list!.pasteHandler(event.detail.data);
+
+    // then make sure that the instance is re-instantiated to hold the new data with the new styles
+    this.changeTabulatorByStyle();
+
+    // create a replace the new rendered list element with the current one.
+    const newListElement = this.list!.render();
+    this.listElement?.replaceWith(newListElement);
+    this.listElement = newListElement;
   }
 
   /**


### PR DESCRIPTION
## Issue
#135

## Cause
The `onpaste` function was updating only the `this.data` property with the output from the internal `onpaste` handler. However, the reference to the `list` was still pointing to the old instance that contained outdated data. As a result, attempting to change the list style on pasted content had no visible effect, since the operation was being performed on the outdated `list` instance behind the scenes.

## Fix Workflow
I updated the implementation to re-instantiate the `list` instance in the main List tool class and then attach the data output from the `onpaste` handler to it.
